### PR TITLE
Fix types for generate option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,8 +48,7 @@ interface Options {
    * By default, the client-side compiler is used. You
    * can also use the server-side rendering compiler
    */
-  // this isn't used yet in plugin
-  // generate?: 'ssr';
+  generate?: string | false;
 
   /**
    * Optionally, preprocess components with svelte.preprocess:

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ interface Options {
    * By default, the client-side compiler is used. You
    * can also use the server-side rendering compiler
    */
-  generate?: string | false;
+  generate?: 'dom' | 'ssr' | false;
 
   /**
    * Optionally, preprocess components with svelte.preprocess:


### PR DESCRIPTION
Hi there :wave:

I've noticed that while the `generate` option is documented in the plugin, it's not exposed in the Typescript's defintions.

I used the type from https://github.com/sveltejs/svelte/blob/d19bcef6901768844cc89cb39d29873381f9969a/src/compiler/interfaces.ts#L111

It would be possible to change the `Options` interface to extend the `CompileOptions` type from Svelte.
```diff
+import { CompileOptions } from "svelte/types/compiler/interfaces";

-interface Options {
+interface Options extends CompileOptions {
```

But it could be misleading since some options are fully handled by the plugin and can't be changed (`format`, `sveltePath`, `css`) and I'm not sure how well it would handle Svelte v2.
I'm definitely not a Typescript expert so I've used the safe way here!

Have a nice day!

PS: if it does not make sense to have the underlying options in the typescript definitions, here is a workaround.

```ts
declare module "rollup-plugin-svelte" {
  interface Options {
    generate?: string | false;
  }
}
```