### PR TITLE
Removes unused import in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Note that we need to install Svelte as well as the plugin, as it's a 'peer depen
 
 ```js
 // rollup.config.js
-import * as fs from 'fs';
 import svelte from 'rollup-plugin-svelte';
 
 export default {


### PR DESCRIPTION
Removes unused import for `fs` in Readme example