### PR TITLE
add customElement typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ export default {
       // Emit CSS as "files" for other plugins to process
       emitCss: true,
 
+      // You can optionally set 'customElement' to 'true' to compile
+      // your components to custom elements (aka web elements)
+      customElement: false,
+
       // Extract CSS into a separate file (recommended).
       // See note below
       css: function (css) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,13 @@ interface Options {
    */
   css?: (css: CssWriter) => any;
 
+
+  /**
+   * Compile Svelte components to custom elements (aka web components).
+   * @default false
+   */
+  customElement?: boolean;
+
   /**
    * let Rollup handle all other warnings normally
    */


### PR DESCRIPTION
As per [the docs](https://github.com/sveltejs/svelte/blob/master/site/content/docs/03-run-time.md#custom-element-api), the `customElement` option is exposed in the public API to compile Svelte components to custom elements. It should be properly typed.