### PR TITLE
fix(types): extend `CompileOptions` interface directly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ interface Options extends CompileOptions {
   /**
    * @type {IncludeAndExclude}
    */
-	include?: string;
+  include?: string;
 
   /**
    * @type {IncludeAndExclude}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { Plugin, RollupWarning } from 'rollup';
 import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
+import { CompileOptions } from 'svelte/types/compiler/interfaces';
 
 interface Css {
   code: any;
@@ -23,7 +24,7 @@ declare class CssWriter {
   toString(): string;
 }
 
-interface Options {
+interface Options extends CompileOptions {
   /**
    * By default, all .svelte and .html files are compiled
    * @default ['.html', '.svelte']
@@ -39,7 +40,8 @@ interface Options {
   /**
    * @type {IncludeAndExclude}
    */
-  include?: string;
+	include?: string;
+
   /**
    * @type {IncludeAndExclude}
    */
@@ -72,13 +74,6 @@ interface Options {
    * Extract CSS into a separate file (recommended).
    */
   css?: (css: CssWriter) => any;
-
-
-  /**
-   * Compile Svelte components to custom elements (aka web components).
-   * @default false
-   */
-  customElement?: boolean;
 
   /**
    * let Rollup handle all other warnings normally

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,12 +48,6 @@ interface Options extends CompileOptions {
   exclude?: string;
 
   /**
-   * By default, the client-side compiler is used. You
-   * can also use the server-side rendering compiler
-   */
-  generate?: 'dom' | 'ssr' | false;
-
-  /**
    * Optionally, preprocess components with svelte.preprocess:
    * https://svelte.dev/docs#svelte_preprocess
    */


### PR DESCRIPTION
Extends the `CompileOptions` directly, since everything gets passed into `svelte/compiler` anyway. Saves us from having an ongoing battle of "oh this is missing too", as we have.

This is separate to (and should land after) #125 

Verified that both PRs work together locally.