### PR TITLE
Omit css-unused-selector when options.css is false, not true

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ module.exports = function svelte(options = {}) {
 				if (major_version >= 3) warnings = compiled.warnings || compiled.stats.warnings;
 
 				warnings.forEach(warning => {
-					if ((options.css || !options.emitCss) && warning.code === 'css-unused-selector') return;
+					if ((!options.css && !options.emitCss) && warning.code === 'css-unused-selector') return;
 
 					if (options.onwarn) {
 						options.onwarn(warning, warning => this.warn(warning));


### PR DESCRIPTION
See: https://github.com/sveltejs/rollup-plugin-svelte/issues/94#issuecomment-685255865

Fixes #94