### PR TITLE
Make filename relative

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,11 +224,10 @@ module.exports = function svelte(options = {}) {
 			if (!filter(id)) return null;
 
 			const extension = path.extname(id);
-
 			if (!~extensions.indexOf(extension)) return null;
-
-
+			
 			const filename = path.relative(process.cwd(), id);
+			
 			const dependencies = [];
 			let preprocessPromise;
 			if (options.preprocess) {
@@ -251,9 +250,7 @@ module.exports = function svelte(options = {}) {
 						Object.assign(preprocessOptions, { filename })
 					).then(code => code.toString());
 				} else {
-					preprocessPromise = preprocess(code, options.preprocess, {
-						filename
-					}).then(processed => {
+					preprocessPromise = preprocess(code, options.preprocess, { filename }).then(processed => {
 						if (processed.dependencies) {
 							dependencies.push(...processed.dependencies);
 						}
@@ -275,9 +272,7 @@ module.exports = function svelte(options = {}) {
 
 				const compiled = compile(
 					code,
-					Object.assign(base_options, fixed_options, {
-						filename
-					}, major_version >= 3 ? null : {
+					Object.assign(base_options, fixed_options, { filename }, major_version >= 3 ? null : {
 						name: capitalize(sanitize(id))
 					})
 				);
@@ -316,6 +311,7 @@ module.exports = function svelte(options = {}) {
 				return compiled.js;
 			});
 		},
+		
 		/**
 		 * If css: true then outputs a single file with all CSS bundled together
 		 */

--- a/index.js
+++ b/index.js
@@ -227,6 +227,8 @@ module.exports = function svelte(options = {}) {
 
 			if (!~extensions.indexOf(extension)) return null;
 
+
+			const filename = path.relative(process.cwd(), id);
 			const dependencies = [];
 			let preprocessPromise;
 			if (options.preprocess) {
@@ -246,11 +248,11 @@ module.exports = function svelte(options = {}) {
 					}
 					preprocessPromise = preprocess(
 						code,
-						Object.assign(preprocessOptions, { filename: id })
+						Object.assign(preprocessOptions, { filename })
 					).then(code => code.toString());
 				} else {
 					preprocessPromise = preprocess(code, options.preprocess, {
-						filename: id
+						filename
 					}).then(processed => {
 						if (processed.dependencies) {
 							dependencies.push(...processed.dependencies);
@@ -274,7 +276,7 @@ module.exports = function svelte(options = {}) {
 				const compiled = compile(
 					code,
 					Object.assign(base_options, fixed_options, {
-						filename: id
+						filename
 					}, major_version >= 3 ? null : {
 						name: capitalize(sanitize(id))
 					})


### PR DESCRIPTION
My main motivation for this PR is that https://github.com/sveltejs/svelte/pull/4856 would embed the `filename` in the compiled code. I don't think that should be an absolute path because that makes it so that builds are not reproducible (e.g. compiled file will be different if you build in different directory or different machine), can leak information (e.g. my username is in my path), etc.

The `filename` is used in three existing places today:
* debug - I think relative path is easier to read for debugging and drops the redundant information
* sourcemap - the examples I see online use relative paths (e.g. [bugsnag article/tutorial](https://www.bugsnag.com/blog/source-maps)), so it seems like an improvement there
* passed to preprocess - I did an `npm link` of this PR against `svelte-preprocess` and all tests passed.