### PR TITLE
Added default value to CssWriter.write map option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare class CssWriter {
   };
   warn: RollupWarning;
   emit(fileName: string, source: string): void;
-  write(dest: string, map: boolean): void;
+  write(dest: string, map?: boolean): void;
   toString(): string;
 }
 

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ class CssWriter {
 		};
 	}
 
-	write(dest = this.filename, map) {
+	write(dest = this.filename, map = true) {
 		const basename = path.basename(dest);
 
 		if (map !== false) {

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ class CssWriter {
 	write(dest = this.filename, map = true) {
 		const basename = path.basename(dest);
 
-		if (map !== false) {
+		if (map) {
 			this.emit(dest, `${this.code}\n/*# sourceMappingURL=${basename}.map */`);
 			this.emit(`${dest}.map`, JSON.stringify({
 				version: 3,


### PR DESCRIPTION
A lot of the examples omit the map parameter for the function in the css option. For example `css: css.write('bundle.css')`. When using typescript in the rollup config, this displays an error because the map parameter is required.

The write function seems to have a condition for explicit false values of the map parameter and for all other values it runs the else statement. By setting the map default value to true, it should behave exactly as before.

Also updated the typings to reflect this change.