### PR TITLE
breaking: Css Writer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,12 @@ interface Options {
   // },
 
   /**
+   * Add extra code for development and debugging purposes.
+   * @default false
+   */
+  dev?: boolean;
+
+  /**
    * Emit CSS as "files" for other plugins to process
    * @default false
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,25 +1,16 @@
-import { Plugin, RollupWarning } from 'rollup';
-import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
+import type { Plugin, RollupWarning, SourceMap as Mapping } from 'rollup';
+import type { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 
-interface Css {
-  code: any;
-  map: any;
-}
+type SourceMap = Omit<Mapping, 'toString' | 'toUrl'>;
 
 declare class CssWriter {
   code: string;
   filename: string;
-  map: {
-    version: number;
-    file?: boolean;
-    sources: string[];
-    sourcesContent: string[];
-    names: any[];
-    mappings: string;
-  };
+  map: false | SourceMap;
   warn: RollupWarning;
   write(file: string, map?: boolean): void;
   emit(name: string, source: string): string;
+  sourcemap(file: string, sourcemap: SourceMap): void;
   toString(): string;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,8 +18,8 @@ declare class CssWriter {
     mappings: string;
   };
   warn: RollupWarning;
-  emit(fileName: string, source: string): void;
-  write(dest: string, map?: boolean): void;
+  write(file: string, map?: boolean): void;
+  emit(name: string, source: string): string;
   toString(): string;
 }
 

--- a/index.js
+++ b/index.js
@@ -70,11 +70,9 @@ function exists(file) {
 }
 
 class CssWriter {
-	constructor(code, filename, map, warn, toAsset) {
+	constructor(context, code, filename, map) {
 		this.code = code;
 		this.filename = filename;
-		this.emit = toAsset;
-		this.warn = warn;
 		this.map = {
 			version: 3,
 			file: null,
@@ -83,6 +81,11 @@ class CssWriter {
 			names: [],
 			mappings: map.mappings
 		};
+
+		this.warn = context.warn;
+		this.emit = (name, source) => context.emitFile({
+			type: 'asset', name, source
+		});
 	}
 
 	write(dest = this.filename, map = true) {
@@ -335,7 +338,7 @@ module.exports = function svelte(options = {}) {
 
 				const filename = Object.keys(bundle)[0].split('.').shift() + '.css';
 
-				const writer = new CssWriter(result, filename, {
+				const writer = new CssWriter(this, result, filename, {
 					sources,
 					sourcesContent,
 					mappings: encode(mappings)

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function exists(file) {
 }
 
 class CssWriter {
-	constructor(context, bundle, code, filename, map) {
+	constructor(context, bundle, isDev, code, filename, map) {
 		this.code = code;
 		this.filename = filename;
 
@@ -106,7 +106,7 @@ class CssWriter {
 				...mapping,
 				file: filename,
 				sources: mapping.sources.map(toRelative),
-			}, null, 2);
+			}, null, isDev ? 2 : 0);
 
 			// use `fileName` to prevent additional Rollup hashing
 			context.emitFile({ type: 'asset', fileName: mapfile, source });
@@ -354,7 +354,7 @@ module.exports = function svelte(options = {}) {
 
 				const filename = Object.keys(bundle)[0].split('.').shift() + '.css';
 
-				const writer = new CssWriter(this, bundle, result, filename, config.sourcemap && {
+				const writer = new CssWriter(this, bundle, !!options.dev, result, filename, config.sourcemap && {
 					sources,
 					sourcesContent,
 					mappings: encode(mappings)

--- a/index.js
+++ b/index.js
@@ -335,8 +335,8 @@ module.exports = function svelte(options = {}) {
 
 					if (config.sourcemap && chunk.map) {
 						const len = sources.length;
-						sources.push(chunk.map.sources[0]);
-						sourcesContent.push(chunk.map.sourcesContent[0]);
+						config.sourcemapExcludeSources || sources.push(chunk.map.sources[0]);
+						config.sourcemapExcludeSources || sourcesContent.push(chunk.map.sourcesContent[0]);
 
 						const decoded = decode(chunk.map.mappings);
 

--- a/index.js
+++ b/index.js
@@ -70,10 +70,11 @@ function exists(file) {
 }
 
 class CssWriter {
-	constructor(context, code, filename, map) {
+	constructor(context, bundle, code, filename, map) {
 		this.code = code;
 		this.filename = filename;
-		this.map = {
+
+		this.map = map && {
 			version: 3,
 			file: null,
 			sources: map.sources,
@@ -86,21 +87,35 @@ class CssWriter {
 		this.emit = (name, source) => context.emitFile({
 			type: 'asset', name, source
 		});
+
+		this.sourcemap = (file, mapping) => {
+			const ref = this.emit(file, this.code);
+			const filename = context.getFileName(ref);
+
+			const mapfile = `${filename}.map`;
+			const toRelative = src => path.relative(path.dirname(file), src);
+
+			if (bundle[filename]) {
+				bundle[filename].source += `\n/*# sourceMappingURL=${mapfile} */`;
+			} else {
+				// This should not ever happen, but just in case...
+				return this.warn(`Missing "${filename}" ("${file}") in bundle; skipping sourcemap!`);
+			}
+
+			const source = JSON.stringify({
+				...mapping,
+				file: filename,
+				sources: mapping.sources.map(toRelative),
+			}, null, 2);
+
+			// use `fileName` to prevent additional Rollup hashing
+			context.emitFile({ type: 'asset', fileName: mapfile, source });
+		}
 	}
 
-	write(dest = this.filename, map = true) {
-		const basename = path.basename(dest);
-
-		if (map) {
-			this.emit(dest, `${this.code}\n/*# sourceMappingURL=${basename}.map */`);
-			this.emit(`${dest}.map`, JSON.stringify({
-				version: 3,
-				file: basename,
-				sources: this.map.sources.map(source => path.relative(path.dirname(dest), source)),
-				sourcesContent: this.map.sourcesContent,
-				names: [],
-				mappings: this.map.mappings
-			}, null, 2));
+	write(dest = this.filename, map = !!this.map) {
+		if (map && this.map) {
+			this.sourcemap(dest, this.map);
 		} else {
 			this.emit(dest, this.code);
 		}
@@ -302,14 +317,14 @@ module.exports = function svelte(options = {}) {
 		/**
 		 * If css: true then outputs a single file with all CSS bundled together
 		 */
-		generateBundle(options, bundle) {
+		generateBundle(config, bundle) {
 			if (css) {
 				// TODO would be nice if there was a more idiomatic way to do this in Rollup
 				let result = '';
 
 				const mappings = [];
-				const sources = [];
 				const sourcesContent = [];
+				const sources = [];
 
 				const chunks = Array.from(cssLookup.keys()).sort().map(key => cssLookup.get(key));
 
@@ -317,17 +332,18 @@ module.exports = function svelte(options = {}) {
 					if (!chunk.code) continue;
 					result += chunk.code + '\n';
 
-					if (chunk.map) {
-						const i = sources.length;
+
+					if (config.sourcemap && chunk.map) {
+						const len = sources.length;
 						sources.push(chunk.map.sources[0]);
 						sourcesContent.push(chunk.map.sourcesContent[0]);
 
 						const decoded = decode(chunk.map.mappings);
 
-						if (i > 0) {
+						if (len > 0) {
 							decoded.forEach(line => {
 								line.forEach(segment => {
-									segment[1] = i;
+									segment[1] = len;
 								});
 							});
 						}
@@ -338,12 +354,10 @@ module.exports = function svelte(options = {}) {
 
 				const filename = Object.keys(bundle)[0].split('.').shift() + '.css';
 
-				const writer = new CssWriter(this, result, filename, {
+				const writer = new CssWriter(this, bundle, result, filename, config.sourcemap && {
 					sources,
 					sourcesContent,
 					mappings: encode(mappings)
-				}, this.warn, (fileName, source) => {
-					this.emitFile({ type: 'asset', fileName, source });
 				});
 
 				css(writer);

--- a/test/index.js
+++ b/test/index.js
@@ -83,7 +83,7 @@ test('does not generate a CSS sourcemap by default', async () => {
 			plugin({
 				css: value => {
 					css = value;
-					css.write('test/sourcemap-test/dist/bundle.css');
+					css.write('bundle.css');
 				}
 			})
 		],
@@ -221,7 +221,7 @@ test('produces readable sourcemap output when `dev` is truthy', async () => {
 				dev: true,
 				css: value => {
 					css = value;
-					css.write('test/sourcemap-test/dist/bundle.css');
+					css.write('bundle.css');
 				}
 			})
 		],
@@ -233,11 +233,11 @@ test('produces readable sourcemap output when `dev` is truthy', async () => {
 		sourcemap: true,
 		file: 'test/sourcemap-test/dist/bundle.js',
 		globals: { 'svelte/internal': 'svelte' },
-		assetFileNames: '[name][extname]',
+		assetFileNames: '[name].[ext]'
 	});
 
-	const content = fs.readFileSync('test/deterministic-css/dist/bundle.css.map', 'utf-8');
-	assert.is(content.includes('\n'), false);
+	const content = fs.readFileSync('test/sourcemap-test/dist/bundle.css.map', 'utf-8');
+	assert.is(content.includes('\n'), true);
 });
 
 test('squelches CSS warnings if css: false', () => {
@@ -411,8 +411,8 @@ test('bundles CSS deterministically', async () => {
 });
 
 test('respects `assetFileNames` Rollup format', async () => {
-	sander.rimrafSync('test/deterministic-css/dist/assets');
-	sander.mkdirSync('test/deterministic-css/dist/assets');
+	sander.rimrafSync('test/deterministic-css/dist');
+	sander.mkdirSync('test/deterministic-css/dist');
 
 	let css;
 

--- a/test/index.js
+++ b/test/index.js
@@ -71,7 +71,38 @@ test('creates a {code, map, dependencies} object, excluding the AST etc', async 
 	assert.equal(Object.keys(compiled), ['code', 'map', 'dependencies']);
 });
 
-test('generates a CSS sourcemap', async () => {
+test('does not generate a CSS sourcemap by default', async () => {
+	sander.rimrafSync('test/sourcemap-test/dist');
+	sander.mkdirSync('test/sourcemap-test/dist');
+
+	let css;
+
+	const bundle = await rollup({
+		input: 'test/sourcemap-test/src/main.js',
+		plugins: [
+			plugin({
+				css: value => {
+					css = value;
+					css.write('test/sourcemap-test/dist/bundle.css');
+				}
+			})
+		],
+		external: ['svelte/internal']
+	});
+
+	await bundle.write({
+		format: 'iife',
+		sourcemap: false,
+		file: 'test/sourcemap-test/dist/bundle.js',
+		globals: { 'svelte/internal': 'svelte' },
+		assetFileNames: '[name][extname]',
+	});
+
+	assert.is(css.code.includes('sourceMappingURL'), false);
+	assert.is(css.map, false);
+});
+
+test('can generate a CSS sourcemap – a la Rollup config', async () => {
 	sander.rimrafSync('test/sourcemap-test/dist');
 	sander.mkdirSync('test/sourcemap-test/dist');
 
@@ -142,6 +173,71 @@ test('generates a CSS sourcemap', async () => {
 			name: null
 		}
 	);
+});
+
+test('respects `sourcemapExcludeSources` Rollup option', async () => {
+	sander.rimrafSync('test/sourcemap-test/dist');
+	sander.mkdirSync('test/sourcemap-test/dist');
+
+	let css;
+
+	const bundle = await rollup({
+		input: 'test/sourcemap-test/src/main.js',
+		plugins: [
+			plugin({
+				css: value => {
+					css = value;
+					css.write('test/sourcemap-test/dist/bundle.css');
+				}
+			})
+		],
+		external: ['svelte/internal']
+	});
+
+	await bundle.write({
+		format: 'iife',
+		sourcemap: true,
+		sourcemapExcludeSources: true,
+		file: 'test/sourcemap-test/dist/bundle.js',
+		globals: { 'svelte/internal': 'svelte' },
+		assetFileNames: '[name][extname]',
+	});
+
+	assert.ok(css.map);
+	assert.is(css.map.sources.length, 0);
+	assert.is(css.map.sourcesContent.length, 0);
+});
+
+test('produces readable sourcemap output when `dev` is truthy', async () => {
+	sander.rimrafSync('test/sourcemap-test/dist');
+	sander.mkdirSync('test/sourcemap-test/dist');
+
+	let css;
+
+	const bundle = await rollup({
+		input: 'test/sourcemap-test/src/main.js',
+		plugins: [
+			plugin({
+				dev: true,
+				css: value => {
+					css = value;
+					css.write('test/sourcemap-test/dist/bundle.css');
+				}
+			})
+		],
+		external: ['svelte/internal']
+	});
+
+	await bundle.write({
+		format: 'iife',
+		sourcemap: true,
+		file: 'test/sourcemap-test/dist/bundle.js',
+		globals: { 'svelte/internal': 'svelte' },
+		assetFileNames: '[name][extname]',
+	});
+
+	const content = fs.readFileSync('test/deterministic-css/dist/bundle.css.map', 'utf-8');
+	assert.is(content.includes('\n'), false);
 });
 
 test('squelches CSS warnings if css: false', () => {
@@ -312,6 +408,92 @@ test('bundles CSS deterministically', async () => {
 		fs.readFileSync('test/deterministic-css/dist/bundle.css', 'utf-8'),
 		fs.readFileSync('test/deterministic-css/expected/bundle.css', 'utf-8')
 	);
+});
+
+test('respects `assetFileNames` Rollup format', async () => {
+	sander.rimrafSync('test/deterministic-css/dist/assets');
+	sander.mkdirSync('test/deterministic-css/dist/assets');
+
+	let css;
+
+	const bundle = await rollup({
+		input: 'test/deterministic-css/src/main.js',
+		plugins: [
+			{
+				resolveId: async (id) => {
+					if (/A\.svelte/.test(id)) {
+						await new Promise(f => setTimeout(f, 50));
+					}
+				}
+			},
+			plugin({
+				css: value => {
+					css = value;
+					css.write('bundle.css');
+				}
+			})
+		],
+		external: ['svelte/internal']
+	});
+
+	await bundle.write({
+		format: 'iife',
+		file: 'test/deterministic-css/dist/bundle.js',
+		globals: { 'svelte/internal': 'svelte' },
+	});
+
+	const files = await sander.readdir('test/deterministic-css/dist/assets');
+	assert.is(files.length, 1, 'produced 1 file output');
+	assert.match(files[0], /^bundle-(\w+)\.css$/);
+});
+
+test('ensures sourcemap and original files point to each other\'s hashed filenames', async () => {
+	sander.rimrafSync('test/deterministic-css/dist/assets');
+	sander.mkdirSync('test/deterministic-css/dist/assets');
+
+	let css;
+
+	const bundle = await rollup({
+		input: 'test/deterministic-css/src/main.js',
+		plugins: [
+			{
+				resolveId: async (id) => {
+					if (/A\.svelte/.test(id)) {
+						await new Promise(f => setTimeout(f, 50));
+					}
+				}
+			},
+			plugin({
+				css: value => {
+					css = value;
+					css.write('bundle.css');
+				}
+			})
+		],
+		external: ['svelte/internal']
+	});
+
+	await bundle.write({
+		format: 'iife',
+		file: 'test/deterministic-css/dist/bundle.js',
+		globals: { 'svelte/internal': 'svelte' },
+		sourcemap: true,
+	});
+
+	const assets = path.resolve('test/deterministic-css/dist/assets');
+
+	const files = await sander.readdir(assets);
+	assert.is(files.length, 2, 'produced 2 file outputs');
+
+	const [file, sourcemap] = files;
+	assert.match(file, /^bundle-(\w+)\.css$/);
+	assert.match(sourcemap, /^bundle-(\w+)\.css\.map$/);
+
+	const data1 = fs.readFileSync(path.join(assets, file), 'utf-8');
+	const data2 = fs.readFileSync(path.join(assets, sourcemap), 'utf-8');
+
+	assert.match(data1, sourcemap, 'file has `sourcemap` reference');
+	assert.match(data2, file, 'sourcemap has `file` reference');
 });
 
 test('handles filenames that happen to contain .svelte', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -92,8 +92,10 @@ test('generates a CSS sourcemap', async () => {
 
 	await bundle.write({
 		format: 'iife',
+		sourcemap: true,
 		file: 'test/sourcemap-test/dist/bundle.js',
-		globals: { 'svelte/internal': 'svelte' }
+		globals: { 'svelte/internal': 'svelte' },
+		assetFileNames: '[name][extname]',
 	});
 
 	const smc = await new SourceMapConsumer(css.map);
@@ -301,7 +303,9 @@ test('bundles CSS deterministically', async () => {
 	await bundle.write({
 		format: 'iife',
 		file: 'test/deterministic-css/dist/bundle.js',
-		globals: { 'svelte/internal': 'svelte' }
+		globals: { 'svelte/internal': 'svelte' },
+		assetFileNames: '[name].[ext]',
+		sourcemap: true,
 	});
 
 	assert.fixture(
@@ -338,7 +342,9 @@ test('handles filenames that happen to contain .svelte', async () => {
 		await bundle.write({
 			format: 'iife',
 			file: 'test/filename-test/dist/bundle.js',
-			globals: { 'svelte/internal': 'svelte' }
+			globals: { 'svelte/internal': 'svelte' },
+			assetFileNames: '[name].[ext]',
+			sourcemap: true,
 		});
 	} catch (err) {
 		console.log(err);


### PR DESCRIPTION
It's really a few fixes, but it since it is a change in the default behavior, safer to just call this breaking.

Doing so means we can also allow #126 to land (re: compatibility concerns) and take this opportunity to finally (!) declare **useful** peer dependency constraints, including Rollup@2x. (Fixing those can be a separate PR) Edit: #138 

***Changes***

Our CSS Writer is broken. While it does work, it's not entirely useful given its environment. As of today (before this PR), the `CssWriter` class:

* Completely ignores [`output.assetFileNames`](https://rollupjs.org/guide/en/#outputassetfilenames), forcing `"bundle.css"` as your final output, even though all other assets/chunks will/are (likely) configured to have hashed filenames.
    _To go back to previous behavior, in their Rollup config, one must set `assetFileNames: "[name].[ext]"` or pass a function to customize the output naming format selectively._

* Completely ignores [`output.sourcemap`](https://rollupjs.org/guide/en/#outputsourcemap) and [`output. sourcemapExcludeSources`](https://rollupjs.org/guide/en/#outputsourcemapexcludesources), which means that we force the emitted CSS files to have sourcemaps, even if we told Rollup to disable sourcemaps outright.
    _To go back to previous behavior, in their Rollup config, one must set `sourcemap: true` – sources are included by default._

* Always prints expanded sourcemaps (aka, multiline JSON). While super minor, there's no reason to go this with production (non-`dev`) output.

I included tests that ensure all these options are respected. And I made sure that when using hashed asset names (Rollup's default), that the sourcemap and CSS file correctly reference each other's hashed names.