### PR TITLE
Allow hydratable option in TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,13 @@ interface Options {
    */
   customElement?: boolean;
 
+
+  /**
+   * Upgrade existing DOM rather than creating new elements
+   * @default false
+   */
+  hydratable?: boolean;
+
   /**
    * let Rollup handle all other warnings normally
    */


### PR DESCRIPTION
Currently, the TypeScript definition doesn't support the property `hydratable`.

Docs: https://svelte.dev/docs#Creating_a_component