### PR TITLE
breaking: version requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,18 +36,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/estree": {
-      "version": "0.0.44",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
-      "integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "14.0.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.11.tgz",
-      "integrity": "sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg==",
-      "dev": true
-    },
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -487,6 +475,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -930,14 +925,12 @@
       }
     },
     "rollup": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
-      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.30.0.tgz",
+      "integrity": "sha512-j4K1hUZfgFM03DUpayd3c7kZW+2wDbI6rj7ssQxpCpL1vsGpaM0vSorxBuePFwQDFq9O2DI6AOQbm174Awsq4w==",
       "dev": true,
       "requires": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
+        "fsevents": "~2.1.2"
       }
     },
     "rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^6.8.0",
     "locate-character": "^2.0.5",
-    "rollup": "^1.32.1",
+    "rollup": "^2.30.0",
     "sander": "^0.6.0",
     "source-map": "^0.7.3",
     "svelte": "^3.24.0",
@@ -41,7 +41,7 @@
     "sourcemap-codec": "^1.4.8"
   },
   "peerDependencies": {
-    "svelte": "*",
-    "rollup": ">=1.19.2"
+    "svelte": ">=3.5.0",
+    "rollup": ">=2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   "peerDependencies": {
     "svelte": ">=3.5.0",
     "rollup": ">=2.0.0"
+  },
+  "engines": {
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
* Require `rollup@2.x` and beyond from now on
* Require `svelte@3.5.0` and beyond from now on (https://github.com/sveltejs/rollup-plugin-svelte/pull/126#issuecomment-689580302)

And defines an `engines.node` requirement for the first time. We're matching Rollup 2.x's restriction – and Node 10+ allows us to start using `async`, if nothing else.

The primary purpose of this PR is maintainer health/sanity, because supporting multi-year-old versions "just because" is not sustainable. Semver allows us to safely move on by cutting a new major release. Users stuck on old versions can continue to use the old version of `rollup-plugin-svelte` & others.

In the short-term, this unblocks #126