### PR TITLE
fix(css): link `sourcemap` with source correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,13 +90,15 @@ class CssWriter {
 
 		this.sourcemap = (file, mapping) => {
 			const ref = this.emit(file, this.code);
-			const filename = context.getFileName(ref);
+			const filename = context.getFileName(ref); // may be "assets/[name][ext]"
 
-			const mapfile = `${filename}.map`;
+			const mapfile = `${filename}.map`; // may be "assets/[name][ext]"
 			const toRelative = src => path.relative(path.dirname(file), src);
 
 			if (bundle[filename]) {
-				bundle[filename].source += `\n/*# sourceMappingURL=${mapfile} */`;
+				// use `basename` because files are siblings
+				// aka, avoid `sourceMappingURL=assets/bundle.css` from `assets/bundle.css`
+				bundle[filename].source += `\n/*# sourceMappingURL=${path.basename(mapfile)} */`;
 			} else {
 				// This should not ever happen, but just in case...
 				return this.warn(`Missing "${filename}" ("${file}") in bundle; skipping sourcemap!`);
@@ -104,7 +106,7 @@ class CssWriter {
 
 			const source = JSON.stringify({
 				...mapping,
-				file: filename,
+				file: path.basename(filename), //=> sibling file
 				sources: mapping.sources.map(toRelative),
 			}, null, isDev ? 2 : 0);
 

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ class CssWriter {
 
 			if (bundle[filename]) {
 				// use `basename` because files are siblings
-				// aka, avoid `sourceMappingURL=assets/bundle.css` from `assets/bundle.css`
+				// aka, avoid `sourceMappingURL=assets/bundle.css.map` from `assets/bundle.css`
 				bundle[filename].source += `\n/*# sourceMappingURL=${path.basename(mapfile)} */`;
 			} else {
 				// This should not ever happen, but just in case...

--- a/test/index.js
+++ b/test/index.js
@@ -101,7 +101,7 @@ test('does not generate a CSS sourcemap by default', async () => {
 		assetFileNames: '[name][extname]',
 	});
 
-	assert.is(css.code.includes('sourceMappingURL'), false);
+	assert.not.match(css.code, 'sourceMappingURL');
 	assert.is(css.map, false);
 });
 
@@ -495,8 +495,8 @@ test('ensures sourcemap and original files point to each other\'s hashed filenam
 	const data1 = fs.readFileSync(path.join(assets, file), 'utf-8');
 	const data2 = fs.readFileSync(path.join(assets, sourcemap), 'utf-8');
 
-	assert.match(data1, sourcemap, 'file has `sourcemap` reference');
-	assert.match(data2, file, 'sourcemap has `file` reference');
+	assert.match(data1, `sourceMappingURL=${sourcemap}`, 'file has `sourcemap` reference');
+	assert.match(data2, `"file":"${file}"`, 'sourcemap has `file` reference');
 });
 
 test('handles filenames that happen to contain .svelte', async () => {


### PR DESCRIPTION
Previously, a `assets/bundle.css` was including this:

```css
/*# sourceMappingURL=assets/bundle.css.map */
```

This resolved in an incorrect sourcemap since when resolved from `assets/bundle.css`, this would produce a request to `assets/assets/bundle.css.map`.

This was also true for the `"file"` key inside the sourcemap itself. 

Both locations now relatively-resolve to one another. AKA, if writing to an `assets` directory (Rollup default) then the output files will _not_ include the `assets/` prefix when referencing one another.