### PR TITLE
fix svelte/compiler import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rollup-plugin-svelte changelog
 
+## Unreleased
+
+* Use `require('svelte/compiler')` rather than `require('svelte/compiler.js')` to work with new Svelte exports map
+
 ## 6.1.0
 
 * feat: allow custom Svelte compilers via new `svelte` option: ([#124](https://github.com/sveltejs/rollup-plugin-svelte/pull/124))

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function autoload() {
 	const pkg = require('svelte/package.json');
 	const version = to_major(pkg.version);
 
-	const { compile, preprocess } = require(version >= 3 ? 'svelte/compiler.js' : 'svelte');
+	const { compile, preprocess } = require(version >= 3 ? 'svelte/compiler' : 'svelte');
 	return { compile, preprocess, version };
 }
 


### PR DESCRIPTION
Fixes second issue seen in https://github.com/sveltejs/svelte/issues/5659 where `svelte/compiler.js` didn't match anything in the exports map.