### PR TITLE
Add svelte-hmr

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If you set `emitCss: false` and your Svelte components contain `<style>` tags, t
 
 In an effort to simplify the ecosystem, this plugin currently includes HMR support via [svelte-hmr](https://github.com/rixo/svelte-hmr). This is a temporary situation, since the community solution will be replaced by the official one once implemented in Svelte's core, and this implementation might differ.
 
-What this option does is adding `esm-hmr` compatible HMR handlers (see [there](https://github.com/rixo/svelte-hmr#whats-hmr-by-the-way) for an in-depth explanation) to the compiled components code.
+What this option does is add `esm-hmr` compatible HMR handlers (see [there](https://github.com/rixo/svelte-hmr#whats-hmr-by-the-way) for an in-depth explanation) to the compiled components code.
 
 By itself, this option won't give you HMR support out of the box, because Rollup doesn't come with a dev server. This option is meant to be used in combination with some [esm-hmr](https://github.com/snowpackjs/esm-hmr) compliant solution, for example [rollup-plugin-hot](https://github.com/rixo/rollup-plugin-hot). You can also use [Nollup](), that aims to be a very fast Rollup compatible dev server with HMR support, but you'll also need some compatibility plugin (like [rollup-plugin-hot-nollup](https://github.com/rixo/rollup-plugin-hot-nollup)) because Nollup implements its own HMR API.
 

--- a/README.md
+++ b/README.md
@@ -134,13 +134,32 @@ This plugin currently includes HMR support via community supported [svelte-hmr](
 
 What this option does is add `esm-hmr` compatible HMR handlers (see [there](https://github.com/rixo/svelte-hmr#whats-hmr-by-the-way) for an in-depth explanation) to the compiled components code.
 
+By itself, this won't give you HMR out of the box with Rollup, because Rollup doesn't come with a dev server. See bellow for some HMR solutions with Rollup, or usage in HMR-enabled Vite.
+
+Note that the `dev` compiler option is required for HMR. **If `compilerOptions.dev` is not set or falsy, the `hot` option will be disabled too.** (Which is probably what you want for a production build.)
+
 ### Options
 
 For now (while using the community implementation), you can pass any of [svelte-hmr's options](https://github.com/rixo/svelte-hmr#options) to the `hot` option of this plugin.
 
+For example:
+
+```js
+svelte({
+  compilerOptions: {
+    dev: true,
+  },
+  hot: {
+    preserveLocalState: true,
+  }
+})
+```
+
 ### HMR with Rollup
 
-By itself, this option won't give you HMR support out of the box with Rollup, because Rollup doesn't come with a dev server. If you want to enable HMR in a Rollup project, you'll need a HMR plugin like [rollup-plugin-hot](https://github.com/rixo/rollup-plugin-hot). Or you can use [Nollup](https://github.com/PepsRyuu/nollup), a Rollup compatible dev server intended for faster rebuild during development (note that you'd also need a `esm-hmr` compatibility plugin with Nollup, like [this](https://github.com/rixo/rollup-plugin-hot-nollup)).
+Rollup doesn't support HMR natively, because it doesn't even come with a dev server. If you want to enable HMR in a Rollup project, you'll need a HMR plugin like [rollup-plugin-hot](https://github.com/rixo/rollup-plugin-hot).
+
+Or you can use [Nollup](https://github.com/PepsRyuu/nollup), a Rollup compatible dev server intended for faster rebuild during development (note that you'd also need a `esm-hmr` compatibility plugin with Nollup, like [this](https://github.com/rixo/rollup-plugin-hot-nollup)).
 
 ### HMR with Vite
 
@@ -156,8 +175,9 @@ import svelte from 'rollup-plugin-svelte'
 export default {
   plugins: [
     svelte({
-      // NOTE that dev and hot should be disabled for production build
-      dev: true,
+      compilerOptions: {
+        dev: true, // should be disabled for production build
+      },
       hot: true,
       emitCss: false,
     }),

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This plugin currently includes HMR support via community supported [svelte-hmr](
 
 What this option does is add `esm-hmr` compatible HMR handlers (see [there](https://github.com/rixo/svelte-hmr#whats-hmr-by-the-way) for an in-depth explanation) to the compiled components code.
 
-### HMR options
+### Options
 
 For now (while using the community implementation), you can pass any of [svelte-hmr's options](https://github.com/rixo/svelte-hmr#options) to the `hot` option of this plugin.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export default {
         handler(warning);
       },
 
-      // You can pass any of the Svelte compiler oiptions
+      // You can pass any of the Svelte compiler options
       compilerOptions: {
 
         // By default, the client-side compiler is used. You
@@ -70,6 +70,13 @@ export default {
         // You can optionally set 'customElement' to 'true' to compile
         // your components to custom elements (aka web elements)
         customElement: false
+      },
+
+      // Enable hot module replacement
+      hot: true,
+      // Or, with options (see https://github.com/rixo/svelte-hmr#options):
+      hot: {
+        preserveLocalState: true
       }
     }),
     // see NOTICE below
@@ -119,6 +126,16 @@ and so on. Then, in `package.json`, set the `svelte` property to point to this `
 By default (when `emitCss: true`) the CSS styles will be emitted into a virtual file, allowing another Rollup plugin – for example, [`rollup-plugin-css-only`](https://www.npmjs.com/package/rollup-plugin-css-only), [`rollup-plugin-postcss`](https://www.npmjs.com/package/rollup-plugin-postcss), etc. – to take responsibility for the new stylesheet. In fact, emitting CSS files _requires_ that you use a Rollup plugin to handle the CSS. Otherwise, your build(s) will fail! This is because this plugin will add an `import` statement to import the emitted CSS file. It's not valid JS to import a CSS file into a JS file, but it allows the CSS to be linked to its respective JS file and is a common pattern that other Rollup CSS plugins know how to handle.
 
 If you set `emitCss: false` and your Svelte components contain `<style>` tags, the compiler will add JavaScript that injects those styles into the page when the component is rendered. That's not the default, because it adds weight to your JavaScript, prevents styles from being fetched in parallel with your code, and can even cause CSP violations.
+
+## Hot module replacement
+
+In an effort to simplify the ecosystem, this plugin currently includes HMR support via [svelte-hmr](https://github.com/rixo/svelte-hmr). This is a temporary situation, since the community solution will be replaced by the official one once implemented in Svelte's core, and this implementation might differ.
+
+What this option does is adding `esm-hmr` compatible HMR handlers (see [there](https://github.com/rixo/svelte-hmr#whats-hmr-by-the-way) for an in-depth explanation) to the compiled components code.
+
+By itself, this option won't give you HMR support out of the box, because Rollup doesn't come with a dev server. This option is meant to be used in combination with some [esm-hmr](https://github.com/snowpackjs/esm-hmr) compliant solution, for example [rollup-plugin-hot](https://github.com/rixo/rollup-plugin-hot). You can also use [Nollup](), that aims to be a very fast Rollup compatible dev server with HMR support, but you'll also need some compatibility plugin (like [rollup-plugin-hot-nollup](https://github.com/rixo/rollup-plugin-hot-nollup)) because Nollup implements its own HMR API.
+
+While using the community implementation, you can pass any of [svelte-hmr's options](https://github.com/rixo/svelte-hmr#options) to the `hot` option of this plugin.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -127,15 +127,44 @@ By default (when `emitCss: true`) the CSS styles will be emitted into a virtual 
 
 If you set `emitCss: false` and your Svelte components contain `<style>` tags, the compiler will add JavaScript that injects those styles into the page when the component is rendered. That's not the default, because it adds weight to your JavaScript, prevents styles from being fetched in parallel with your code, and can even cause CSP violations.
 
+
 ## Hot module replacement
 
-In an effort to simplify the ecosystem, this plugin currently includes HMR support via [svelte-hmr](https://github.com/rixo/svelte-hmr). This is a temporary situation, since the community solution will be replaced by the official one once implemented in Svelte's core, and this implementation might differ.
+This plugin currently includes HMR support via community supported [svelte-hmr](https://github.com/rixo/svelte-hmr). This will be replaced by the official implementation once it is supported by Svelte's compiler itself.
 
 What this option does is add `esm-hmr` compatible HMR handlers (see [there](https://github.com/rixo/svelte-hmr#whats-hmr-by-the-way) for an in-depth explanation) to the compiled components code.
 
-By itself, this option won't give you HMR support out of the box, because Rollup doesn't come with a dev server. This option is meant to be used in combination with some [esm-hmr](https://github.com/snowpackjs/esm-hmr) compliant solution, for example [rollup-plugin-hot](https://github.com/rixo/rollup-plugin-hot). You can also use [Nollup](), that aims to be a very fast Rollup compatible dev server with HMR support, but you'll also need some compatibility plugin (like [rollup-plugin-hot-nollup](https://github.com/rixo/rollup-plugin-hot-nollup)) because Nollup implements its own HMR API.
+### HMR options
 
-While using the community implementation, you can pass any of [svelte-hmr's options](https://github.com/rixo/svelte-hmr#options) to the `hot` option of this plugin.
+For now (while using the community implementation), you can pass any of [svelte-hmr's options](https://github.com/rixo/svelte-hmr#options) to the `hot` option of this plugin.
+
+### HMR with Rollup
+
+By itself, this option won't give you HMR support out of the box with Rollup, because Rollup doesn't come with a dev server. If you want to enable HMR in a Rollup project, you'll need a HMR plugin like [rollup-plugin-hot](https://github.com/rixo/rollup-plugin-hot). Or you can use [Nollup](https://github.com/PepsRyuu/nollup), a Rollup compatible dev server intended for faster rebuild during development (note that you'd also need a `esm-hmr` compatibility plugin with Nollup, like [this](https://github.com/rixo/rollup-plugin-hot-nollup)).
+
+### HMR with Vite
+
+This plugin can also be used directly with Vite 2, that supports a subset of Rollup plugin API, and has native HMR.
+
+Example of the minimal config you need to enable Svelte HMR in Vite 2:
+
+`vite.config.js`
+
+```js
+import svelte from 'rollup-plugin-svelte'
+
+export default {
+  plugins: [
+    svelte({
+      // NOTE that dev and hot should be disabled for production build
+      dev: true,
+      hot: true,
+      emitCss: false,
+    }),
+  ],
+}
+```
+
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,12 +77,6 @@ interface Options {
      noDisableCss: boolean;
      injectCss: boolean;
      cssEjectDelay: number;
-
-     /**
-      * Nollup compatibility mode.
-      * @default !!process.env.NOLLUP
-      */
-     nollup: boolean;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,52 @@ interface Options {
 
   /** Custom warnings handler; defers to Rollup as default. */
   onwarn(warning: RollupWarning, handler: WarningHandler): void;
+
+  /** Enable/configure HMR */
+  hot?: {
+    /**
+     * Enable state preservation when a component is updated by HMR for every
+     * components.
+     * @default false
+     */
+    preserveState: boolean;
+
+    /**
+     * If this string appears anywhere in your component's code, then local
+     * state won't be preserved, even when noPreserveState is false.
+     * @default '@hmr:reset'
+     */
+    noPreserveStateKey: string;
+
+    /**
+     * If this string appears next to a `let` variable, the value of this
+     * variable will be preserved accross HMR updates.
+     * @default '@hmr:keep'
+     */
+     preserveStateKey: string;
+
+    /**
+     * Prevent doing a full reload on next HMR update after fatal error.
+     * @default false
+     */
+     noReload: boolean;
+
+     /**
+      * Try to recover after runtime errors in component init.
+      * @default true
+      */
+     optimistic: boolean;
+
+     noDisableCss: boolean;
+     injectCss: boolean;
+     cssEjectDelay: number;
+
+     /**
+      * Nollup compatibility mode.
+      * @default !!process.env.NOLLUP
+      */
+     nollup: boolean;
+  }
 }
 
 export default function svelte(options?: Partial<Options>): Plugin;

--- a/index.js
+++ b/index.js
@@ -51,9 +51,6 @@ module.exports = function (options = {}) {
 			console.warn(`${PREFIX} Forcing \`"compilerOptions.dev": true\` because "hot" is truthy.`);
 			compilerOptions.dev = true;
 		}
-		if (hotOptions.nollup == null) {
-			hotOptions.nollup = !!process.env.NOLLUP;
-		}
 	}
 
 	return {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (options = {}) {
 
 	// [filename]:[chunk]
 	const cache_emit = new Map;
-	const { onwarn, emitCss=true, hot: hotOptions } = rest;
+	const { onwarn, emitCss=true } = rest;
 
 	if (emitCss) {
 		if (compilerOptions.css) {
@@ -44,14 +44,12 @@ module.exports = function (options = {}) {
 		compilerOptions.css = false;
 	}
 
-	const makeHot = hotOptions && createMakeHot({ walk });
-
-	if (hotOptions) {
-		if (!compilerOptions.dev) {
-			console.warn(`${PREFIX} Forcing \`"compilerOptions.dev": true\` because "hot" is truthy.`);
-			compilerOptions.dev = true;
-		}
+	if (rest.hot && !compilerOptions.dev) {
+		console.info(`${PREFIX} Disabling HMR because "dev" option is disabled.`);
+		rest.hot = false;
 	}
+
+	const makeHot = rest.hot && createMakeHot({ walk });
 
 	return {
 		name: 'svelte',
@@ -133,13 +131,13 @@ module.exports = function (options = {}) {
 				cache_emit.set(fname, compiled.css);
 			}
 
-			if (hotOptions) {
+			if (makeHot) {
 				compiled.js.code = makeHot({
 					id,
 					compiledCode: compiled.js.code,
 					hotOptions: {
 						injectCss: !rest.emitCss,
-						...hotOptions,
+						...rest.hot,
 					},
 					compiled,
 					originalCode: code,

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ const relative = require('require-relative');
 const { createFilter } = require('rollup-pluginutils');
 const { compile, preprocess, walk } = require('svelte/compiler');
 const { createMakeHot } = require('svelte-hmr');
-const { appendCompatNollup } = require('rollup-plugin-hot-nollup');
 
 const PREFIX = '[rollup-plugin-svelte]';
 const pkg_export_errors = new Set();
@@ -59,14 +58,6 @@ module.exports = function (options = {}) {
 
 	return {
 		name: 'svelte',
-
-		// append compat transform plugin for Nollup's HMR API
-		...hotOptions && hotOptions.nollup && {
-			options: appendCompatNollup(name, {
-				include: rest.include,
-				exclude: rest.exclude,
-			}),
-		},
 
 		/**
 		 * Resolve an import's full filepath.

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,28 +61,6 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "requires": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
-        }
-      }
-    },
-    "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
-    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -792,11 +770,6 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
-    "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -848,14 +821,6 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
-      }
-    },
-    "rollup-plugin-hot-nollup": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-hot-nollup/-/rollup-plugin-hot-nollup-0.1.2.tgz",
-      "integrity": "sha512-QE4/CO7CFWSwZDmp/K+bMEOdP+i9aZiEw2u1sF+BiYE+0VQTu/FfzhJUxI0PDthBjzLZfEW31rwQJhVueuSL8w==",
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0"
       }
     },
     "rollup-pluginutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,28 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+        }
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -770,6 +792,11 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -821,6 +848,14 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
+      }
+    },
+    "rollup-plugin-hot-nollup": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-hot-nollup/-/rollup-plugin-hot-nollup-0.1.2.tgz",
+      "integrity": "sha512-QE4/CO7CFWSwZDmp/K+bMEOdP+i9aZiEw2u1sF+BiYE+0VQTu/FfzhJUxI0PDthBjzLZfEW31rwQJhVueuSL8w==",
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0"
       }
     },
     "rollup-pluginutils": {
@@ -952,6 +987,11 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.30.0.tgz",
       "integrity": "sha512-z+hdIACb9TROGvJBQWcItMtlr4s0DBUgJss6qWrtFkOoIInkG+iAMo/FJZQFyDBQZc+dul2+TzYSi/tpTT5/Ag==",
       "dev": true
+    },
+    "svelte-hmr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.12.0.tgz",
+      "integrity": "sha512-NYpzqME/jlTBL+JLilznH2QnQbREJvwikWjLNpJuekhcCqIWbnO7hrNnMZCgAKiQHAKEdiohtjARJhO7nMZGbg=="
     },
     "table": {
       "version": "5.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -954,9 +954,9 @@
       "dev": true
     },
     "svelte-hmr": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.12.0.tgz",
-      "integrity": "sha512-NYpzqME/jlTBL+JLilznH2QnQbREJvwikWjLNpJuekhcCqIWbnO7hrNnMZCgAKiQHAKEdiohtjARJhO7nMZGbg=="
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.12.4.tgz",
+      "integrity": "sha512-txg3Gt9PPxioHN45UO88s5DtNQZ1V5DB9EDpXz29L7WX2HpqPj6w8leD9/eynC4PbTz87bMvxNLdDiR/xdg73g=="
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "require-relative": "^0.8.7",
-    "rollup-plugin-hot-nollup": "^0.1.2",
     "rollup-pluginutils": "^2.8.2",
     "svelte-hmr": "^0.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "dependencies": {
     "require-relative": "^0.8.7",
-    "rollup-pluginutils": "^2.8.2"
+    "rollup-plugin-hot-nollup": "^0.1.2",
+    "rollup-pluginutils": "^2.8.2",
+    "svelte-hmr": "^0.12.0"
   },
   "peerDependencies": {
     "svelte": ">=3.5.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "require-relative": "^0.8.7",
     "rollup-pluginutils": "^2.8.2",
-    "svelte-hmr": "^0.12.0"
+    "svelte-hmr": "^0.12.4"
   },
   "peerDependencies": {
     "svelte": ">=3.5.0",


### PR DESCRIPTION
Hey!

How would you feel about adding `svelte-hmr` in this plugin?

This PR is the gist of it.

This can be seen in action in [this branch](https://github.com/rixo/svelte-template-hot/tree/rollup-plugin-svelte) of my template.

The main point of contention is handling `emitCss: true`... `svelte-hmr` doesn't play very well with this currently, but it could probably be adapted to just change the CSS classes of existing elements, and rely on another CSS plugin for hot injection of CSS. Unfortunately, my hot fork of the postcss plugin doesn't to play along very well either...

In the end, maybe just forcing `emitCss: false` when `hot: true` would be sufficient? Still one hard point here would be that, ideally, the `bundle.css` (or so) normally produced by the user config would need to be overwritten with a blank file; both to avoid unsavory 404 on the missing CSS files in dev, and to avoid loading CSS from a previous build that would risk interfering with the HMR loaded one. This could probably be achieved by emitting empty files from the plugin, instead of the actual CSS.

Also, I've included a Nollup compat plugin that is automatically injected in the Rollup config when Nollup is detected (through an env variable it sets). Given there's only 2 HMR options for Rollup (to my knowledge), and Nollup has a real added value in dev with its speed, I'm keen to support it transparently to the user if possible. This compat plugin is injected automatically both by `rollup-plugin-hot` and `rollup-plugin-svelte-hot`, since people might want to use HMR only with Nollup, or Nollup in a non Svelte project.

Happy to discuss any point... Starting this PR to get the ball rolling!