### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,16 @@ name: CI
 on:
   push:
     paths-ignore:
-      - "*.md"
-      - "LICENSE"
-      - "index.d.ts"
+      - '*.md'
+      - 'LICENSE'
+      - 'index.d.ts'
     branches:
       - master
   pull_request:
     paths-ignore:
-      - "*.md"
-      - "LICENSE"
-      - "index.d.ts"
+      - '*.md'
+      - 'LICENSE'
+      - 'index.d.ts'
     branches:
       - master
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,16 @@ name: CI
 on:
   push:
     paths-ignore:
-      - '*.md'
-      - 'LICENSE'
-      - 'index.d.ts'
+      - "*.md"
+      - "LICENSE"
+      - "index.d.ts"
     branches:
       - master
   pull_request:
     paths-ignore:
-      - '*.md'
-      - 'LICENSE'
-      - 'index.d.ts'
+      - "*.md"
+      - "LICENSE"
+      - "index.d.ts"
     branches:
       - master
 
@@ -26,17 +26,18 @@ jobs:
         nodejs: [10, 12, 14]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.nodejs }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.nodejs }}
+          cache: npm
 
-    - name: Install
-      run: npm ci
+      - name: Install
+        run: npm ci
 
-    - name: Linter
-      if: matrix.os != 'windows-latest'
-      run: npm run lint
+      - name: Linter
+        if: matrix.os != 'windows-latest'
+        run: npm run lint
 
-    - name: Test
-      run: npm test
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

Fix #188

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
