### PR TITLE
Forward package exports warning to `onwarn`

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,8 +136,15 @@ module.exports = function (options = {}) {
 		 */
 		generateBundle() {
 			if (pkg_export_errors.size > 0) {
-				console.warn(`\n${PREFIX} The following packages did not export their \`package.json\` file so we could not check the "svelte" field. If you had difficulties importing svelte components from a package, then please contact the author and ask them to export the package.json file.\n`);
-				console.warn(Array.from(pkg_export_errors, s => `- ${s}`).join('\n') + '\n');
+				const pkg_warning = `\n${PREFIX} The following packages did not export their \`package.json\` file so we could not check the "svelte" field. If you had difficulties importing svelte components from a package, then please contact the author and ask them to export the package.json file.\n`;
+				const pkg_exports = Array.from(pkg_export_errors, s => `- ${s}`).join('\n') + '\n';
+				const warning = pkg_warning + '\n' + pkg_exports;
+
+				if (onwarn) {
+					onwarn(warning, this.warn);
+				} else {
+					console.warn(warning);
+				}
 			}
 		}
 	};


### PR DESCRIPTION
Closes #181 

This PR proposes forwarding the package exports warning to the `onwarn` plugin option if defined. This enables the consumer to omit the package exports warning without modifying the existing plugin API.

**Desired UX**

```js
// rollup.config.js

svelte({
  onwarn: (warning) => {
    // do not print the package exports warning
    if (/(^-\s|package.json)/.test(warning)) return;

    // print all other warnings
    console.warn(warning);
  },
}),
```

By default, the warning will still be emitted if no `onwarn` argument is passed to the `rollup-plugin-svelte` plugin.