### PR TITLE
fix package resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
 			"version": "7.1.1",
 			"license": "MIT",
 			"dependencies": {
-				"@rollup/pluginutils": "^4.1.0",
-				"require-relative": "^0.8.7"
+				"@rollup/pluginutils": "^4.1.0"
 			},
 			"devDependencies": {
 				"eslint": "^7.14.0",
@@ -1102,11 +1101,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/require-relative": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-			"integrity": "sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg=="
 		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
@@ -2280,11 +2274,6 @@
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true
-		},
-		"require-relative": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-			"integrity": "sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg=="
 		},
 		"resolve-from": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 		"node": ">=10"
 	},
 	"dependencies": {
-		"require-relative": "^0.8.7",
 		"@rollup/pluginutils": "^4.1.0"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
I'm not sure what the story is with #198 but it didn't work, because the `get_dir` function was called inside the `catch` block which defeats the object.

This PR takes a much simpler approach — it just walks up the tree looking for `node_modules/<name>/package.json`. Crude, but should work in all the cases we care about (it doesn't need to reimplement the entire Node module resolution algo, it just needs to find libraries with a `pkg.svelte`).

I assume we also need to respect the `svelte` export condition, but that seems like something that should happen separately.