### PR TITLE
warn about missing svelte export condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,8 @@ module.exports = function (options = {}) {
 			}
 
 			if (pkg) {
-				// resolve pkg.svelte first
+				// resolve pkg.svelte first for backwards compatibility
+				// we should resolve it after exports longer-term
 				if (entry === '.' && pkg.svelte) {
 					return path.resolve(dir, pkg.svelte);
 				}

--- a/index.js
+++ b/index.js
@@ -75,10 +75,11 @@ module.exports = function (options = {}) {
 			const entry = parts.join('/') || '.';
 
 			let pkg;
+			let dir;
 
 			let search_dir = importer;
 			while (search_dir !== (search_dir = path.dirname(search_dir))) {
-				const dir = path.join(search_dir, 'node_modules', name);
+				dir = path.join(search_dir, 'node_modules', name);
 				const file = path.join(dir, 'package.json');
 				if (fs.existsSync(file)) {
 					pkg = JSON.parse(fs.readFileSync(file, 'utf-8'));
@@ -100,7 +101,7 @@ module.exports = function (options = {}) {
 						resolve(pkg, entry, { conditions: ['svelte'] });
 
 						if (!warned) {
-							console.error(`\n\u001B[1m\u001B[31mWARNING: Your @rollup/plugin-node-resolve configuration's 'exportConditions' array should include 'svelte'. See https://github.com/sveltejs/rollup-plugin-svelte#svelte-exports-condition for more information\u001B[39m\u001B[22m\n'`);
+							console.error('\n\u001B[1m\u001B[31mWARNING: Your @rollup/plugin-node-resolve configuration\'s \'exportConditions\' array should include \'svelte\'. See https://github.com/sveltejs/rollup-plugin-svelte#svelte-exports-condition for more information\u001B[39m\u001B[22m\n');
 							warned = true;
 						}
 					} catch (e) {

--- a/index.js
+++ b/index.js
@@ -87,27 +87,27 @@ module.exports = function (options = {}) {
 				}
 			}
 
-			if (pkg) {
-				// resolve pkg.svelte first for backwards compatibility
-				// we should resolve it after exports longer-term
-				if (entry === '.' && pkg.svelte) {
-					return path.resolve(dir, pkg.svelte);
-				}
+			if (!pkg) return;
 
-				const resolved = await this.resolve(importee, importer, { skipSelf: true });
+			// resolve pkg.svelte first for backwards compatibility
+			// we should resolve it after exports longer-term
+			if (entry === '.' && pkg.svelte) {
+				return path.resolve(dir, pkg.svelte);
+			}
 
-				// if we can't resolve this import without the `svelte` condition, warn the user
-				if (!resolved) {
-					try {
-						resolve(pkg, entry, { conditions: ['svelte'] });
+			const resolved = await this.resolve(importee, importer, { skipSelf: true });
 
-						if (!warned) {
-							console.error('\n\u001B[1m\u001B[31mWARNING: Your @rollup/plugin-node-resolve configuration\'s \'exportConditions\' array should include \'svelte\'. See https://github.com/sveltejs/rollup-plugin-svelte#svelte-exports-condition for more information\u001B[39m\u001B[22m\n');
-							warned = true;
-						}
-					} catch (e) {
-						// do nothing, this isn't a Svelte library
+			// if we can't resolve this import without the `svelte` condition, warn the user
+			if (!resolved) {
+				try {
+					resolve(pkg, entry, { conditions: ['svelte'] });
+
+					if (!warned) {
+						console.error('\n\u001B[1m\u001B[31mWARNING: Your @rollup/plugin-node-resolve configuration\'s \'exportConditions\' array should include \'svelte\'. See https://github.com/sveltejs/rollup-plugin-svelte#svelte-exports-condition for more information\u001B[39m\u001B[22m\n');
+						warned = true;
 					}
+				} catch (e) {
+					// do nothing, this isn't a Svelte library
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "rollup-plugin-svelte",
-	"version": "7.1.1",
+	"version": "7.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rollup-plugin-svelte",
-			"version": "7.1.1",
+			"version": "7.1.2",
 			"license": "MIT",
 			"dependencies": {
-				"@rollup/pluginutils": "^4.1.0"
+				"@rollup/pluginutils": "^4.1.0",
+				"resolve.exports": "^2.0.0"
 			},
 			"devDependencies": {
 				"eslint": "^7.14.0",
@@ -1109,6 +1110,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/resolve.exports": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
+			"integrity": "sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/rimraf": {
@@ -2280,6 +2289,11 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
+		},
+		"resolve.exports": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
+			"integrity": "sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg=="
 		},
 		"rimraf": {
 			"version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
 		"node": ">=10"
 	},
 	"dependencies": {
-		"@rollup/pluginutils": "^4.1.0"
+		"@rollup/pluginutils": "^4.1.0",
+		"resolve.exports": "^2.0.0"
 	},
 	"peerDependencies": {
-		"svelte": ">=3.5.0",
-		"rollup": ">=2.0.0"
+		"rollup": ">=2.0.0",
+		"svelte": ">=3.5.0"
 	},
 	"devDependencies": {
 		"eslint": "^7.14.0",

--- a/test/index.js
+++ b/test/index.js
@@ -8,40 +8,44 @@ const sander = require('sander');
 
 const plugin = require('..');
 
-test('resolves using pkg.svelte', () => {
+const context = {
+	resolve: () => 'resolved'
+};
+
+test('resolves using pkg.svelte', async () => {
 	const p = plugin();
 	assert.is(
-		p.resolveId('widget', path.resolve('test/foo/main.js')),
+		await p.resolveId.call(context, 'widget', path.resolve('test/foo/main.js')),
 		path.resolve('test/node_modules/widget/src/Widget.svelte')
 	);
 });
 
-test('ignores built-in modules', () => {
-	const p = plugin();
-	assert.ok(
-		p.resolveId('path', path.resolve('test/foo/main.js')) == null
-	);
-});
-
-test('ignores esm modules that do not export package.json', () => {
-	const p = plugin();
-	assert.ok(
-		p.resolveId('esm-no-pkg-export', path.resolve('test/foo/main.js')) == null
-	);
-});
-
-test('resolves esm module that exports package.json', () => {
+test('ignores built-in modules', async () => {
 	const p = plugin();
 	assert.is(
-		p.resolveId('esm-component', path.resolve('test/foo/main.js')),
+		await p.resolveId.call(context, 'path', path.resolve('test/foo/main.js')), undefined
+	);
+});
+
+test('ignores esm modules that do not export package.json', async () => {
+	const p = plugin();
+	assert.is(
+		await p.resolveId.call(context, 'esm-no-pkg-export', path.resolve('test/foo/main.js')), undefined
+	);
+});
+
+test('resolves esm module that exports package.json', async () => {
+	const p = plugin();
+	assert.is(
+		await p.resolveId.call(context, 'esm-component', path.resolve('test/foo/main.js')),
 		path.resolve('test/node_modules/esm-component/src/Component.svelte')
 	);
 });
 
-test('ignores virtual modules', () => {
+test('ignores virtual modules', async () => {
 	const p = plugin();
-	assert.ok(
-		p.resolveId('path', path.resolve('\0some-plugin-generated-module')) == null
+	assert.is(
+		await p.resolveId.call(context, 'path', path.resolve('\0some-plugin-generated-module')), undefined
 	);
 });
 


### PR DESCRIPTION
We plan to release a version of `svelte-package` that encourages package authors to omit the `default` export condition. To resolve these packages, Rollup users are required to have `exportConditions: ['svelte']` in their `@rollup/plugin-node-resolve` config.

With this change, we can identify cases where the field is not configured, and print a loud warning that will hopefully allow people to self-diagnose resolution failures and fix them.