### PR TITLE
feat: set compilerOptions.css to 'external' when emitCss was true

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,8 @@ module.exports = function (options = {}) {
 	const { onwarn, emitCss = true } = rest;
 
 	if (emitCss) {
-		const [majorVer, minorVer] = VERSION.split('.');
-		const cssOptionValue = majorVer > 3 || (majorVer >= 3 && minorVer >= 53) ? 'external' : true;
+		const [majorVer] = VERSION.split('.');
+		const cssOptionValue = majorVer > 3 ? 'external' : true;
 		if (compilerOptions.css) {
 			console.warn(
 				`${PREFIX} Forcing \`"compilerOptions.css": ${typeof cssOptionValue === 'string' ? `"${cssOptionValue}"` : cssOptionValue}\` because "emitCss" was truthy.`

--- a/index.js
+++ b/index.js
@@ -42,12 +42,14 @@ module.exports = function (options = {}) {
 	const { onwarn, emitCss = true } = rest;
 
 	if (emitCss) {
+		const [majorVer, minorVer] = VERSION.split('.');
+		const cssOptionValue = majorVer > 3 || (majorVer >= 2 && minorVer >= 53) ? 'external' : true;
 		if (compilerOptions.css) {
 			console.warn(
-				`${PREFIX} Forcing \`"compilerOptions.css": "external"\` because "emitCss" was truthy.`
+				`${PREFIX} Forcing \`"compilerOptions.css": ${typeof cssOptionValue === 'string' ? `"${cssOptionValue}"` : cssOptionValue}\` because "emitCss" was truthy.`
 			);
 		}
-		compilerOptions.css = 'external';
+		compilerOptions.css = cssOptionValue;
 	}
 
 	return {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = function (options = {}) {
 
 	if (emitCss) {
 		const [majorVer, minorVer] = VERSION.split('.');
-		const cssOptionValue = majorVer > 3 || (majorVer >= 2 && minorVer >= 53) ? 'external' : true;
+		const cssOptionValue = majorVer > 3 || (majorVer >= 3 && minorVer >= 53) ? 'external' : true;
 		if (compilerOptions.css) {
 			console.warn(
 				`${PREFIX} Forcing \`"compilerOptions.css": ${typeof cssOptionValue === 'string' ? `"${cssOptionValue}"` : cssOptionValue}\` because "emitCss" was truthy.`

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = function (options = {}) {
 
 	if (emitCss) {
 		const [majorVer] = VERSION.split('.');
-		const cssOptionValue = majorVer > 3 ? 'external' : true;
+		const cssOptionValue = majorVer > 3 ? 'external' : false;
 		if (compilerOptions.css) {
 			console.warn(
 				`${PREFIX} Forcing \`"compilerOptions.css": ${typeof cssOptionValue === 'string' ? `"${cssOptionValue}"` : cssOptionValue}\` because "emitCss" was truthy.`

--- a/index.js
+++ b/index.js
@@ -44,10 +44,10 @@ module.exports = function (options = {}) {
 	if (emitCss) {
 		if (compilerOptions.css) {
 			console.warn(
-				`${PREFIX} Forcing \`"compilerOptions.css": false\` because "emitCss" was truthy.`
+				`${PREFIX} Forcing \`"compilerOptions.css": "external"\` because "emitCss" was truthy.`
 			);
 		}
-		compilerOptions.css = false;
+		compilerOptions.css = 'external';
 	}
 
 	return {


### PR DESCRIPTION
to remove below warning
```
compilerOptions.css as a boolean is deprecated. Use 'external' instead of false.
```

set css to 'external' while svelte version >= 4

latest [svelte compiler](https://svelte.dev/docs/svelte-compiler) has changed `css` option values to
```
css?: 'injected' | 'external' | 'none' | boolean;
```