### PR TITLE
Add Svelte 5 RC to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	},
 	"peerDependencies": {
 		"rollup": ">=2.0.0",
-		"svelte": ">=3.5.0"
+		"svelte": ">=3.5.0 || >=5.0.0-next.120"
 	},
 	"devDependencies": {
 		"eslint": "^7.14.0",


### PR DESCRIPTION
Per https://github.com/sveltejs/rollup-plugin-svelte/issues/218, adds the Svelte 5 Release Candidate as an allowable peer dependency.