### PR TITLE
fix: set compilerOptions.css to 'injected' when emitCss is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,17 +45,17 @@ module.exports = function (options = {}) {
 	const cache_emit = new Map();
 	const { onwarn, emitCss = true } = rest;
 
-	if (emitCss) {
-		const cssOptionValue = majorVersion > 3 ? 'external' : false;
-		if (compilerOptions.css) {
-			console.warn(
-				`${PREFIX} Forcing \`"compilerOptions.css": ${
-					typeof cssOptionValue === 'string' ? `"${cssOptionValue}"` : cssOptionValue
-				}\` because "emitCss" was truthy.`
-			);
-		}
-		compilerOptions.css = cssOptionValue;
+	// Override `compilerOptions.css` based on `emitCss`
+	const cssOptionValue =
+		majorVersion > 3 ? (emitCss ? 'external' : 'injected') : emitCss ? false : true;
+	if (compilerOptions.css !== undefined && compilerOptions.css !== cssOptionValue) {
+		console.warn(
+			`${PREFIX} Forcing "compilerOptions.css": ${
+				typeof cssOptionValue === 'string' ? `"${cssOptionValue}"` : cssOptionValue
+			} because "emitCss" was ${emitCss ? 'truthy' : 'falsy'}.`
+		);
 	}
+	compilerOptions.css = cssOptionValue;
 
 	return {
 		name: 'svelte',


### PR DESCRIPTION
Since the default value for `compilerOptions.css` has been changed to `'external'` in Svelte 5, using only `emitCss: false` results in `<style>` tag not being included anywhere in the output.

Since the intention of `emitCss: false` is to inject CSS into JavaScript, I think it's better to set `compilerOptions.css` to `'injected'` when `emitCss: false`.