### PR TITLE
chore: Update uvu and resolve vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"rollup": "^2.33.3",
 				"source-map": "^0.7.3",
 				"svelte": "^4.0.0",
-				"uvu": "^0.4.1"
+				"uvu": "^0.5.6"
 			},
 			"engines": {
 				"node": ">=10"
@@ -363,10 +363,11 @@
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -456,10 +457,11 @@
 			"dev": true
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -515,10 +517,11 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -1078,18 +1081,6 @@
 			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
 			"dev": true
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/magic-string": {
 			"version": "0.30.10",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
@@ -1333,13 +1324,11 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -1549,15 +1538,6 @@
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
-		"node_modules/totalist": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
-			"integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1592,16 +1572,16 @@
 			}
 		},
 		"node_modules/uvu": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.4.1.tgz",
-			"integrity": "sha512-JgAGSdts0VawIRPpnG4t1G5O0RoSrkJZTvTH+iSrFrlsJq9w12hksrfvd8wHIVAw/215T7WfQalCwYa3vN8tTA==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+			"integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"dequal": "^2.0.0",
-				"diff": "^4.0.2",
+				"diff": "^5.0.0",
 				"kleur": "^4.0.3",
-				"sade": "^1.7.3",
-				"totalist": "^2.0.0"
+				"sade": "^1.7.3"
 			},
 			"bin": {
 				"uvu": "bin.js"
@@ -1644,12 +1624,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		}
 	},
@@ -1922,9 +1896,9 @@
 			"dev": true
 		},
 		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
@@ -1999,9 +1973,9 @@
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.1.0",
@@ -2041,9 +2015,9 @@
 			"dev": true
 		},
 		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
 			"dev": true
 		},
 		"doctrine": {
@@ -2476,15 +2450,6 @@
 			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
 			"dev": true
 		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
 		"magic-string": {
 			"version": "0.30.10",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
@@ -2667,13 +2632,10 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"dev": true,
-			"requires": {
-				"lru-cache": "^6.0.0"
-			}
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -2832,12 +2794,6 @@
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
-		"totalist": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
-			"integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
-			"dev": true
-		},
 		"type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2863,16 +2819,15 @@
 			}
 		},
 		"uvu": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.4.1.tgz",
-			"integrity": "sha512-JgAGSdts0VawIRPpnG4t1G5O0RoSrkJZTvTH+iSrFrlsJq9w12hksrfvd8wHIVAw/215T7WfQalCwYa3vN8tTA==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+			"integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
 			"dev": true,
 			"requires": {
 				"dequal": "^2.0.0",
-				"diff": "^4.0.2",
+				"diff": "^5.0.0",
 				"kleur": "^4.0.3",
-				"sade": "^1.7.3",
-				"totalist": "^2.0.0"
+				"sade": "^1.7.3"
 			}
 		},
 		"v8-compile-cache": {
@@ -2900,12 +2855,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
-		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"rollup": "^2.33.3",
 		"source-map": "^0.7.3",
 		"svelte": "^4.0.0",
-		"uvu": "^0.4.1"
+		"uvu": "^0.5.6"
 	},
 	"keywords": [
 		"svelte",


### PR DESCRIPTION
This PR updates the `uvu` test package to its latest version, and resolves 3 vulnerabilities (via npm audit fix):

```plaintext
brace-expansion  1.0.0 - 1.1.11
brace-expansion Regular Expression Denial of Service vulnerability - https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
fix available via `npm audit fix`
node_modules/brace-expansion

cross-spawn  7.0.0 - 7.0.4
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix`
node_modules/cross-spawn

semver  7.0.0 - 7.5.1
Severity: high
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix`
```

Test script is running fine.

> [!NOTE]
> Consider dropping `uvu` as it seems abandoned, and instead moving to a more modern testing framework.

Thanks for Svelte, guys!  It is KING.