### PR TITLE
fix: make emitCss: false work with Svelte 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,8 @@ module.exports = function (options = {}) {
 			);
 		}
 		compilerOptions.css = cssOptionValue;
+	} else if (majorVersion > 4) {
+		compilerOptions.css = 'injected';
 	}
 
 	return {

--- a/test/index.js
+++ b/test/index.js
@@ -114,6 +114,25 @@ test('respects `sourcemapExcludeSources` Rollup option', async () => {
 	assert.is(map.sourcesContent, null);
 });
 
+test('injects CSS with `emitCss: false', async () => {
+	const p = plugin({emitCss: false});
+
+	const transformed = await p.transform(
+		`
+			<h1>Hello!</h1>
+
+			<style>
+				h1 {
+					color: red;
+				}
+			</style>
+		`,
+		'test.svelte'
+	);
+
+	assert.ok(transformed.code.includes('color:red'));
+});
+
 test('squelches "unused CSS" warnings if `emitCss: false`', () => {
 	const p = plugin({
 		emitCss: false,


### PR DESCRIPTION
Fixes #235 

This PR is an alternative to https://github.com/sveltejs/rollup-plugin-svelte/pull/232, but also provides a test for the fix.