### PR TITLE
fix: relax test case to allow different hash values

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -333,7 +333,7 @@ test('handles filenames that happen to contain ".svelte"', async () => {
 
 	assert.match(
 		fs.readFileSync('test/filename-test/dist/bundle.css', 'utf8'),
-		/h1\.svelte-bt9zrl\s*{\s*color:\s*red;?\s*}/
+		/h1\.svelte-[_a-zA-Z0-9-]+\s*{\s*color:\s*red;?\s*}/
 	);
 });
 


### PR DESCRIPTION
 svelte 5.38.9 changed the default from css content to filename and this caused a fail in svelte-ecosystem-ci

didn't limit the hash format on purpose, instead allowing a sequence of valid css classname chars